### PR TITLE
Potential fix for code scanning alert no. 2: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,8 +441,8 @@ Tracks managed secrets and their sync status.
 | source_vault_id | TEXT | Source vault ID |
 | target_vault_id | TEXT | Target vault ID |
 | secret_name | TEXT | Secret name |
-| source_checksum | TEXT | MD5 hash of source value |
-| target_checksum | TEXT | MD5 hash of target value |
+| source_checksum | TEXT | SHA-256 hash of source value |
+| target_checksum | TEXT | SHA-256 hash of target value |
 | last_sync_time | INTEGER | Unix timestamp |
 | last_sync_status | TEXT | success, failed, in_sync |
 | last_sync_error | TEXT | Error message if failed |

--- a/sync/engine.go
+++ b/sync/engine.go
@@ -1,7 +1,7 @@
 package sync
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"log/slog"
@@ -381,9 +381,9 @@ func matchPattern(pattern, name string) bool {
 	return false
 }
 
-// hashString creates an MD5 hash of a string
+// hashString creates a SHA-256 hash of a string
 func hashString(s string) string {
-	hash := md5.Sum([]byte(s))
+	hash := sha256.Sum256([]byte(s))
 	return fmt.Sprintf("%x", hash)
 }
 

--- a/sync/engine_test.go
+++ b/sync/engine_test.go
@@ -653,7 +653,7 @@ func TestMatchPattern(t *testing.T) {
 }
 
 func TestHashString(t *testing.T) {
-	if hashString("test") != "098f6bcd4621d373cade4e832627b4f6" {
+	if hashString("test") != "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08" {
 		t.Error("unexpected hash for test")
 	}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/pacorreia/vaults-syncer/security/code-scanning/2](https://github.com/pacorreia/vaults-syncer/security/code-scanning/2)

Use a strong modern hash for non-password hashing: replace MD5 with SHA-256 in `sync/engine.go`.

Best fix with minimal functional change:
- In imports, replace `crypto/md5` with `crypto/sha256`.
- Update `hashString` to compute `sha256.Sum256([]byte(s))`.
- Keep output format as hex string via `fmt.Sprintf("%x", hash)` so stored checksum representation remains string-based and behavior at call sites is unchanged.

This single helper change fixes all 4 alert variants because all flagged flows pass through `hashString`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
